### PR TITLE
SQLite converter: Support the more complex schemas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 			"includes/class-wp-error.php",
 			"includes/class-wxz-converter.php",
 			"includes/class-wxz-reader.php",
+			"includes/class-wxz-sqlite.php",
 			"includes/class-wxz-validator.php"
 		]
 	},

--- a/includes/class-wxz-sqlite.php
+++ b/includes/class-wxz-sqlite.php
@@ -1,0 +1,196 @@
+<?php
+
+class WXZ_SQLite {
+	private $db;
+	private $tables = array();
+	private $schemas = array();
+	public function __construct( $filename ) {
+		$this->db = new PDO( 'sqlite:' . $filename );
+	}
+
+	private function get_sqlite_field_type( $type ) {
+		switch ( $type ) {
+			case 'string':
+				return 'TEXT';
+			case 'boolean':
+				return 'INTEGER';
+			case 'integer':
+				return 'INTEGER';
+			default:
+				throw new Exception( 'Unknown type ' . $type );
+		}
+	}
+
+	private function get_sqlite_field_type_id( $type ) {
+		switch ( $this->get_sqlite_field_type( $type ) ) {
+			case 'TEXT':
+				return SQLITE3_TEXT;
+			case 'INTEGER':
+				return SQLITE3_INTEGER;
+			default:
+				throw new Exception( 'Unknown type' );
+		}
+	}
+
+	public function create_tables( $schemas, $dir ) {
+		$this->db->exec( 'CREATE TABLE IF NOT EXISTS config (
+			id INTEGER PRIMARY KEY,
+			name TEXT,
+			value TEXT
+		)' );
+
+		$this->db->exec( 'CREATE TABLE IF NOT EXISTS content (
+			id INTEGER PRIMARY KEY,
+			name TEXT
+		)' );
+
+		// Create tables according to schemas.
+		foreach ( $schemas as $type => $json_schema_url ) {
+			$this->schemas[ $type ] = json_decode( file_get_contents( $dir . str_replace( 'https://wordpress.org', '', $json_schema_url ) ) );
+			$create_table  = array();
+
+			$keys = array();
+			foreach ( $this->schemas[ $type ]->properties as $key => $spec ) {
+				if ( isset( $spec->{'$ref'} ) ) {
+					$spec = json_decode( file_get_contents( $dir . str_replace( 'https://wordpress.org', '', $spec->{'$ref'} ) ) );
+					$this->schemas[ $type ]->properties->$key = $spec;
+				}
+				if ( ! isset( $spec->type ) ) {
+					continue;
+				}
+				if ( 'array' === $spec->type && 'terms' === $key ) {
+					$keys[ $key ] = 'array';
+					// Will be created below.
+					continue;
+				}
+				if ( 'array' === $spec->type && 'meta' === $key ) {
+					$keys[ $key ] = 'array';
+					// Will be created below.
+					continue;
+				}
+				if ( 'array' === $spec->type && 'content' === $key ) {
+					continue;
+					// Will be created below.
+					continue;
+				}
+				if ( is_array( $this->schemas[ $type ]->properties->$key->type ) ) {
+					if ( isset( $this->schemas[ $type ]->properties->$key->properties ) ) {
+						foreach ( $this->schemas[ $type ]->properties->$key->properties as $property => $data ) {
+							if ( 'then' === $key ) {
+								$create_table[] = $property . ' ' . $this->get_sqlite_field_type( $data->type );
+								$keys[ $property ] = $data->type;
+							} else {
+								$create_table[] = $key . '_' . $property . ' ' . $this->get_sqlite_field_type( $data->type );
+								$keys[ $key . '_' . $property ] = $data->type;
+							}
+						}
+					} elseif ( isset( $this->schemas[ $type ]->properties->$key->items ) ) {
+						// content
+					}
+				} elseif ( 'id' === $key ) {
+					$create_table[] = 'id INTEGER PRIMARY KEY';
+					$keys[ $key ] = 'integer';
+				} else {
+					$create_table[] = $key . ' ' . $this->get_sqlite_field_type( $this->schemas[ $type ]->properties->$key->type );
+					$keys[ $key ] = 'integer';
+				}
+			}
+
+			$this->db->exec( 'CREATE TABLE IF NOT EXISTS ' . $type . ' (' . implode( ', ', $create_table ) . ')' );
+			$this->tables[ $type ] = $keys;
+
+			if ( isset( $keys['meta'] ) ) {
+				$this->db->exec( 'CREATE TABLE IF NOT EXISTS ' . $type . '_meta (
+					id INTEGER PRIMARY KEY,
+					' . rtrim( $type, 's' ) . '_id INTEGER REFERENCES ' . $type . '( id ),
+					`key` TEXT,
+					value TEXT
+				)' );
+			}
+		}
+
+		$this->db->exec( 'CREATE TABLE IF NOT EXISTS posts_terms (
+			id INTEGER PRIMARY KEY,
+			post_id INTEGER REFERENCES posts( id ),
+			term_id INTEGER REFERENCES terms( id ),
+			UNIQUE( post_id, term_id ) ON CONFLICT REPLACE
+		)' );
+
+
+	}
+
+	public function insert_config( stdClass $data ) {
+		$stmt = $this->db->prepare( 'INSERT INTO config (name, value) VALUES (:name, :value)' );
+
+		foreach ( $data as $key => $value ) {
+			$stmt->bindValue( ':name', $key, $this->get_sqlite_field_type_id( 'string' ) );
+			$stmt->bindValue( ':value', $value, $this->get_sqlite_field_type_id( 'string' ) );
+			$stmt->execute();
+		}
+	}
+
+	public function insert_meta( $type, $id, $meta ) {
+		$stmt = $this->db->prepare( 'INSERT INTO ' . $type . '_meta (' . rtrim( $type, 's' ) . '_id, `key`, value) VALUES (:post_id, :key, :value)' );
+
+		foreach ( $meta as $data ) {
+			$stmt->bindValue( ':'. rtrim( $type, 's' ) . '_id', $id, $this->get_sqlite_field_type_id( 'integer' ) );
+			$stmt->bindValue( ':key', $data->key, $this->get_sqlite_field_type_id( 'string' ) );
+			$stmt->bindValue( ':value', $data->value, $this->get_sqlite_field_type_id( 'string' ) );
+			$stmt->execute();
+		}
+	}
+
+	public function insert_post_terms( $post_id, $terms ) {
+		$stmt = $this->db->prepare( 'INSERT INTO posts_terms (post_id, term_id) VALUES (:post_id, :term_id)' );
+
+		foreach ( $terms as $term_id ) {
+			$stmt->bindValue( ':post_id', $post_id, $this->get_sqlite_field_type_id( 'integer' ) );
+			$stmt->bindValue( ':term_id', $term_id, $this->get_sqlite_field_type_id( 'integer' ) );
+			$stmt->execute();
+		}
+	}
+
+	public function insert( $type, stdClass $data ) {
+		$insert_data = array();
+		foreach ( $this->schemas[ $type ]->properties as $key => $spec ) {
+			if ( ! isset( $spec->type ) ) {
+				continue;
+			}
+			if ( 'array' === $spec->type && 'terms' === $key && isset( $data->$key ) ) {
+				$this->insert_post_terms( $data->id, $data->$key );
+				unset( $data->$key );
+				continue;
+			}
+			if ( 'array' === $spec->type && 'meta' === $key && isset( $data->$key ) ) {
+				$this->insert_meta( $type, $data->id, $data->$key );
+				unset( $data->$key );
+				continue;
+			}
+			if ( ! isset( $data->$key ) ) {
+				continue;
+			}
+			if ( is_array( $this->schemas[ $type ]->properties->$key->type ) ) {
+				if ( isset( $this->schemas[ $type ]->properties->$key->properties ) ) {
+					foreach ( $this->schemas[ $type ]->properties->$key->properties as $property => $data ) {
+						if ( 'then' === $key ) {
+							$insert_data[ $property ] = $data->$type->$property;
+						} else {
+							$insert_data[ $key . '_' . $property ] = $data->$type->$property;
+						}
+					}
+				} elseif ( isset( $this->schemas[ $type ]->properties->$key->items ) ) {
+					// content
+				}
+			} else {
+				$insert_data[ $key ] = $data->$key;
+			}
+		}
+
+		$stmt = $this->db->prepare( 'INSERT OR IGNORE INTO ' . $type . '(' . implode( ', ', array_keys( $insert_data ) ) . ') VALUES (:' . implode( ', :', array_keys( $insert_data ) ) . ')' );
+
+		foreach ( $insert_data as $key => $value ) {
+			$stmt->bindValue( ':' . $key, $value, $this->get_sqlite_field_type_id( gettype( $value ) ) );
+		}
+		return $stmt->execute();
+	}
+}

--- a/wxz-sqlite.php
+++ b/wxz-sqlite.php
@@ -11,73 +11,23 @@ $reader = new WXZ_Reader();
 foreach ( $_SERVER['argv'] as $filename ) {
 	$sql_filename = basename( $filename, '.zip' ) . '.sqlite';
 	unlink( $sql_filename );
-	$db_file = new PDO( 'sqlite:'.__DIR__ . '/' . $sql_filename );
+
+	$db = new WXZ_SQLite( __DIR__ . '/' . $sql_filename );
+	$db->create_tables( WXZ_Validator::$schemas, __DIR__ );
+
+	$tables = array();
 	foreach( $reader->read( $filename ) as $filename => $content ) {
 		$type = dirname( $filename );
 		$name = basename( $filename, '.json' );
 		$item = json_decode( $content );
 
 		if ( 'site' === $type && 'config' === $name ) {
-			$db_file->exec( 'CREATE TABLE IF NOT EXISTS config (
-				id INTEGER PRIMARY KEY,
-				name TEXT,
-				value TEXT
-			)' );
-
-			$insert = 'INSERT INTO config (name, value) VALUES (:name, :value)';
-			$stmt = $db_file->prepare( $insert );
-
-			foreach ( $item as $key => $value ) {
-				$stmt->bindValue( ':name', $key, PDO::PARAM_STR );
-				$stmt->bindValue( ':value', $value, PDO::PARAM_STR );
-				$stmt->execute();
-			}
+			$db->insert_config( $item );
 			continue;
 		}
 
-		if ( isset( WXZ_Validator::$schemas[ $type ] ) ) {
-			$schema = json_decode( file_get_contents( __DIR__ . str_replace( 'https://wordpress.org', '', WXZ_Validator::$schemas[ $type ] ) ) );
-			$sql = 'CREATE TABLE IF NOT EXISTS ' . $type;
-			$insert1 = 'INSERT OR IGNORE INTO ' . $type;
-			$insert2 = ') VALUES';
-
-			$t = '(';
-			$k = '(';
-			foreach ( $schema->properties as $key => $spec ) {
-				if ( ! isset( $spec->type ) ) {
-					continue;
-				}
-				$sql .= $t . $key . ' ';
-				switch ( $schema->properties->$key->type ) {
-					case 'string': $sql.= 'text'; break;
-					default: $sql .=  $schema->properties->$key->type;
-				}
-
-				if ( 'id' === $key ) {
-					$sql .= ' PRIMARY KEY';
-				}
-				$t = ',';
-
-				if ( isset( $item->$key ) ) {
-					$insert1 .= $k . $key;
-					$insert2 .= $k . ':' . $key;
-					$k = ',';
-				}
-			}
-			$db_file->exec( $sql . ')' );
-
-			$stmt = $db_file->prepare( $insert1 . $insert2 . ');' );
-			foreach ( $item as $key => $val ) {
-				if ( isset( $schema->properties->$key->type ) ) {
-					switch ( $schema->properties->$key->type ) {
-						case 'string': $param = SQLITE3_TEXT; break;
-						case 'integer': $param = SQLITE3_INTEGER; break;
-						case 'bool': $param = SQLITE3_INTEGER; break;
-					}
-					$stmt->bindValue( ':' . $key, $val, $param );
-				}
-			}
-			$stmt->execute();
+		foreach ( $item as $key => $val ) {
+			$db->insert( $type, $item );
 		}
 	}
 	echo 'Wrote ', $sql_filename, '.', PHP_EOL;


### PR DESCRIPTION
This is a refactor of the SQLite conversion script that handles most of the complexities of our (current) JSON Schema complexities. It generates these tables from these (`echo .schema | sqlite filename.sqlite`).

```
CREATE TABLE config (
	id INTEGER PRIMARY KEY,
	name TEXT,
	value TEXT
);
CREATE TABLE content (
	id INTEGER PRIMARY KEY,
	name TEXT
);
CREATE TABLE users (
	id INTEGER PRIMARY KEY,
	login TEXT,
	name TEXT,
	name_firstname TEXT,
	name_lastname TEXT,
	name_displayname TEXT,
	email TEXT,
	url TEXT
);
CREATE TABLE users_meta (
	id INTEGER PRIMARY KEY,
	user_id INTEGER REFERENCES users( id ),
	`key` TEXT,
	value TEXT
);
CREATE TABLE terms (
	id INTEGER PRIMARY KEY,
	taxonomy TEXT,
	slug TEXT,
	parent INTEGER,
	name TEXT
);
CREATE TABLE terms_meta (
	id INTEGER PRIMARY KEY,
	term_id INTEGER REFERENCES terms( id ),
	`key` TEXT,
	value TEXT
);
CREATE TABLE posts (
	id INTEGER PRIMARY KEY,
	title TEXT,
	slug TEXT,
	author INTEGER,
	type TEXT,
	postStatus TEXT,
	published TEXT,
	modified TEXT,
	parent INTEGER,
	password TEXT,
	menuOrder INTEGER,
	sticky INTEGER,
	commentsOpen INTEGER,
	pingsOpen INTEGER
);
CREATE TABLE posts_meta (
	id INTEGER PRIMARY KEY,
	post_id INTEGER REFERENCES posts( id ),
	`key` TEXT,
	value TEXT
);
CREATE TABLE posts_terms (
	id INTEGER PRIMARY KEY,
	post_id INTEGER REFERENCES posts( id ),
	term_id INTEGER REFERENCES terms( id ),
	UNIQUE( post_id, term_id ) ON CONFLICT REPLACE
);

```

Notes:
- It creates a m:n intermediate table for post-term relationships.
- The user name is defined as either string or object, this is handled via keys of the sort name_displayName.
- Foreign keys are defined as such.

The plan is to also implement the reverse direction.