### PR TITLE
Ignore meta if the value is empty

### DIFF
--- a/includes/class-wxz-converter.php
+++ b/includes/class-wxz-converter.php
@@ -252,7 +252,7 @@ class WXZ_Converter {
 			}
 
 			foreach ( $wp->postmeta as $meta ) {
-				if( (string) $meta->meta_value  === "" ) {
+				if ( strval( $meta->meta_value ) === "" ) {
 					continue;
 				}
 

--- a/includes/class-wxz-converter.php
+++ b/includes/class-wxz-converter.php
@@ -252,6 +252,10 @@ class WXZ_Converter {
 			}
 
 			foreach ( $wp->postmeta as $meta ) {
+				if( empty( (string) $meta->meta_value ) ) {
+					continue;
+				}
+
 				$post['meta'][] = array(
 					'key'   => (string) $meta->meta_key,
 					'value' => (string) $meta->meta_value,

--- a/includes/class-wxz-converter.php
+++ b/includes/class-wxz-converter.php
@@ -252,7 +252,7 @@ class WXZ_Converter {
 			}
 
 			foreach ( $wp->postmeta as $meta ) {
-				if( empty( (string) $meta->meta_value ) ) {
+				if( (string) $meta->meta_value  === "" ) {
 					continue;
 				}
 


### PR DESCRIPTION
Empty properties are filtered before encoding to JSON which results in meta keys with no associated value, violating the JSON meta schema. This fix will not add meta where the value is empty.