### PR TITLE
Add the ID field to the required fields for post and term schemas

### DIFF
--- a/schema/post.json
+++ b/schema/post.json
@@ -111,5 +111,5 @@
 	},
 
 	"additionalProperties": false,
-	"required": [ "version" ]
+	"required": [ "version", "id" ]
 }

--- a/schema/term.json
+++ b/schema/term.json
@@ -46,5 +46,5 @@
 	},
 
 	"additionalProperties": false,
-	"required": [ "version", "taxonomy" ]
+	"required": [ "version", "taxonomy", "id" ]
 }


### PR DESCRIPTION
Since posts and terms are referenced by ID, these fields should be mandatory.

I suppose this could also be true for other objects that have an ID field. The filename also has an ID in the name.

I came up with this because I am importing terms for a post and (this is done by ID)[https://github.com/wp-importer/wxz-tools/blob/main/schema/post.json#L52]. Therefore, I need terms to have an ID so that I can get a list of already importer terms (and their actual IDs) based on the ID in the JSON file and then add the corresponding terms to the post. 

Does this make sense?